### PR TITLE
Added Travis-ci integration. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+
+install: 
+ - mkdir RI
+ - git clone https://github.com/WASdev/standards.jsr352.jbatch
+ - cd standards.jsr352.jbatch
+ - mvn clean install
+ - cd ..
+ - rm -rf standards.jsr352.jbatch
+script: mvn  install
+
+branches:
+  only:
+  - master


### PR DESCRIPTION
We are manually building the jbatch RI source first and then running the tck tests. 

There are a couple different approaches to reduce the build time (by not building the RI each time), which we can talk offline I guess.
