### PR TITLE
Fix for Issue #32

### DIFF
--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyBatchletWithPropertiesImpl.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyBatchletWithPropertiesImpl.java
@@ -45,6 +45,10 @@ public class MyBatchletWithPropertiesImpl extends AbstractBatchlet {
     public String myDefaultProp1 = "Should get overwritten by default value";
     
     @Inject    
+    @BatchProperty (name="parentProp")
+    public String parentProp;
+    
+    @Inject    
     @BatchProperty
     public String mySubmittedProp = "This EYECATCHER should get overwritten by a submitted prop.";
     

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
@@ -17,6 +17,7 @@
 package com.ibm.jbatch.tck.tests.jslxml;
 
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertObjEquals;
+import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.io.File;
 import java.util.Properties;
@@ -259,6 +260,39 @@ public class PropertySubstitutionTests {
 			String result = System.getProperty("property.junit.result");
 			Reporter.log("Test result: " + result + "<p>");
 			assertObjEquals("batchletPropValue", result);
+		} catch (Exception e) {
+			handleException(METHOD, e);
+		}
+	}
+	
+	/*
+	 * @testName: testParentPropertyOutOfScope
+	 * 
+	 * @assertion: For a given artifact, the only properties that are injectable via @BatchProperty 
+	 * are those which are defined at the level of the artifact itself (JSR 352 9.3.2)
+	 * 
+	 * @test_Strategy: Issue a job with a job level property and NO batchlet level property of the 
+	 * same name. Verify that the job level property is NOT injected.
+	 */
+	@Test
+	@org.junit.Test
+	public void testParentPropertyOutOfScope() throws Exception {
+
+		String METHOD = "testParentPropertyOutOfScope";
+
+		try {
+			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+
+			Reporter.log("Set system property:property.junit.propName=parentProp<p>");
+			System.setProperty("property.junit.propName", "parentProp");
+
+			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
+
+			String wrongResult = "SHOULD_BE_OUT_OF_SCOPE_OF_@INJECT_@BATCHLETPROPERTY";
+			String result = System.getProperty("property.junit.result");
+			Reporter.log("Test result: " + result + "<p>");
+			assertWithMessage("The parent property should be out of scope!", !wrongResult.equals(result));
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_properties2.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_properties2.xml
@@ -20,6 +20,7 @@
 		<property name="myprop1" value="step2" />
 		<property name="myprop2" value="#{jobProperties['myprop1']}" />
 		<property name="batchletProp" value="JOB_OVERRIDE" />
+		<property name="parentProp" value="SHOULD_BE_OUT_OF_SCOPE_OF_@INJECT_@BATCHLETPROPERTY" />
 	</properties>
 	<step id="step1" next="#{jobProperties['myprop1']}">
 	    <properties>


### PR DESCRIPTION
Added a test that ensures job level properties are not in scope of
@BatchProperty injection. From the spec  (JSR 352 9.3.2): "For a given artifact, the only
properties that are injectable via @BatchProperty are those which are
defined at the level of the artifact itself"
