### PR TITLE
addressed bugzilla bug 4706, from issue #17

### DIFF
--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
@@ -84,7 +84,7 @@ public class ExecutionTests {
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			assertObjEquals("Completed", jobExec.getExitStatus());
+			assertObjEquals("STEP 1 COMPLETED", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -110,7 +110,7 @@ public class ExecutionTests {
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			assertObjEquals("Completed", jobExec.getExitStatus());
+			assertObjEquals("STEP 2 COMPLETED", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -269,7 +269,7 @@ public class ExecutionTests {
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			assertObjEquals("Completed", jobExec.getExitStatus());
+			assertObjEquals("STEP 2 COMPLETED", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
@@ -83,6 +83,8 @@ public class ExecutionTests {
 
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
+			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			assertObjEquals("Completed", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -107,6 +109,8 @@ public class ExecutionTests {
 
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
+			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			assertObjEquals("Completed", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -131,6 +135,8 @@ public class ExecutionTests {
 
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
+			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			assertObjEquals("Completed", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -138,8 +144,9 @@ public class ExecutionTests {
 
 	/*
 	 * @testName: testInvokeJobWithNextElement
-	 * @assertion: FIXME
-	 * @test_Strategy: FIXME
+	 * @assertion: job will finish successfully as COMPLETED
+	 * @test_Strategy: The job is written with a Next Element to control a step transition. The status of the second step is checked
+	 * 		for completion, to prove that the step was properly called from the Next Element.
 	 */
 	@Test
 	@org.junit.Test  
@@ -155,6 +162,8 @@ public class ExecutionTests {
 
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
+			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			assertObjEquals("Step2_Completed", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -188,8 +197,9 @@ public class ExecutionTests {
 
 	/*
 	 * @testName: testInvokeJobWithStopElement
-	 * @assertion: FIXME
-	 * @test_Strategy: FIXME
+	 * @assertion: job will finish successfully as STOPPED after the first step
+	 * @test_Strategy: A Stop Element is used to terminate the job after the first step. If the job continues, a different status is returned,
+	 * 	and the test fails.
 	 */
 	@Test
 	@org.junit.Test  
@@ -205,6 +215,8 @@ public class ExecutionTests {
 
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
+			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			assertObjEquals("TEST_STOPPED", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -238,8 +250,9 @@ public class ExecutionTests {
 
 	/*
 	 * @testName: testInvokeJobSimpleChunk
-	 * @assertion: FIXME
-	 * @test_Strategy: FIXME
+	 * @assertion: job will finish successfully as COMPLETED
+	 * @test_Strategy: A small chunk is run with a reader, processor, and writer. If all items are read, processed, and written
+	 * 	without failure, then the exit status will be good and the test will pass.
 	 */
 	@Test
 	@org.junit.Test
@@ -255,6 +268,8 @@ public class ExecutionTests {
 
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
+			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			assertObjEquals("Completed", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
@@ -136,7 +136,7 @@ public class ExecutionTests {
 			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			assertObjEquals("Completed", jobExec.getExitStatus());
+			assertObjEquals("STEP 3 COMPLETED", jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_1step.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_1step.xml
@@ -18,5 +18,6 @@
 <job id="job_batchlet_1step" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
 	<step id="step1" >
 		<batchlet ref="myBatchletImpl" />
+		<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
 	</step>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_1step.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_1step.xml
@@ -18,6 +18,6 @@
 <job id="job_batchlet_1step" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
 	<step id="step1" >
 		<batchlet ref="myBatchletImpl" />
-		<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
+		<end on="VERY GOOD INVOCATION" exit-status="STEP 1 COMPLETED"/>
 	</step>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_2steps.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_2steps.xml
@@ -21,6 +21,6 @@
 	</step>
 	<step id="step2" >
 		<batchlet ref="myBatchletImpl" />
-		<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
+		<end on="VERY GOOD INVOCATION" exit-status="STEP 2 COMPLETED"/>
 	</step>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_2steps.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_2steps.xml
@@ -21,5 +21,6 @@
 	</step>
 	<step id="step2" >
 		<batchlet ref="myBatchletImpl" />
+		<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
 	</step>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_4steps.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_4steps.xml
@@ -24,7 +24,7 @@
 	</step>
 	<step id="step3">
 		<batchlet ref="myBatchletImpl" />
-		<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
+		<end on="VERY GOOD INVOCATION" exit-status="STEP 3 COMPLETED"/>
 	</step>	
 	<step id="step4" next="step3">
 		<batchlet ref="myBatchletImpl" />

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_4steps.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_4steps.xml
@@ -24,6 +24,7 @@
 	</step>
 	<step id="step3">
 		<batchlet ref="myBatchletImpl" />
+		<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
 	</step>	
 	<step id="step4" next="step3">
 		<batchlet ref="myBatchletImpl" />

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_nextElement.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_batchlet_nextElement.xml
@@ -18,12 +18,13 @@
 <job id="job_batchlet_nextElement" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
 	<step id="step1">
 		<batchlet ref="myBatchletImpl" />
-		<next on="COMPLETED" to="step2"/>
+		<next on="VERY GOOD INVOCATION" to="step2"/>
 		<fail on="FAILED" exit-status="TEST_FAIL"/>
 		<end on="ENDED" exit-status="TEST_ENDED"/>
 		<stop on="STOPPED" exit-status="TEST_STOPPED"/>
 	</step>
 	<step id="step2" >
 		<batchlet ref="myBatchletImpl" />
+		<end on="VERY GOOD INVOCATION" exit-status="Step2_Completed"/>
 	</step>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_chunk_simple.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_chunk_simple.xml
@@ -25,5 +25,6 @@
 		 <processor ref="doSomethingItemProcessorImpl"/>
 		 <writer ref="doSomethingItemWriterImpl"></writer>
 		 </chunk> 	
+		 <end on="COMPLETED" exit-status="Completed"/>
 	</step>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_chunk_simple.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_chunk_simple.xml
@@ -25,6 +25,6 @@
 		 <processor ref="doSomethingItemProcessorImpl"/>
 		 <writer ref="doSomethingItemWriterImpl"></writer>
 		 </chunk> 	
-		 <end on="COMPLETED" exit-status="Completed"/>
+		 <end on="COMPLETED" exit-status="STEP 2 COMPLETED"/>
 	</step>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_flow_batchlet_4steps.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_flow_batchlet_4steps.xml
@@ -30,7 +30,7 @@
 		</step>	
 		<step id="step4" >
 			<batchlet ref="myBatchletImpl" />
-			<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
+			<end on="VERY GOOD INVOCATION" exit-status="STEP 4 COMPLETED"/>
 		</step>
 	</flow>
 </job>

--- a/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_flow_batchlet_4steps.xml
+++ b/com.ibm.jbatch.tck/src/main/resources/META-INF/batch-jobs/job_flow_batchlet_4steps.xml
@@ -30,6 +30,7 @@
 		</step>	
 		<step id="step4" >
 			<batchlet ref="myBatchletImpl" />
+			<end on="VERY GOOD INVOCATION" exit-status="Completed"/>
 		</step>
 	</flow>
 </job>


### PR DESCRIPTION
Covers items #1-4 from bugzilla bug 4706
Adds more detailed exit statuses to tests
Adds more assertions to ensure tests ran properly
