### PR TITLE
refactored testSplitFlowContextPropagation()

### DIFF
--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/inner/ParallelContextPropagationArtifacts.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/inner/ParallelContextPropagationArtifacts.java
@@ -17,28 +17,15 @@
 package com.ibm.jbatch.tck.artifacts.inner;
 
 import java.io.Serializable;
-import java.util.List;
 
 import javax.batch.api.AbstractBatchlet;
 import javax.batch.api.partition.AbstractPartitionAnalyzer;
 import javax.batch.api.partition.PartitionCollector;
-import javax.batch.operations.JobOperator;
-import javax.batch.runtime.BatchRuntime;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.JobInstance;
-import javax.batch.runtime.StepExecution;
 import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
-import javax.inject.Named;
 
-import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import static org.junit.Assert.assertEquals;
-
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 public class ParallelContextPropagationArtifacts {
 
@@ -72,8 +59,7 @@ public static String GOOD_EXIT_STATUS = "VERY GOOD INVOCATION";
 			}
 
 			String data = stepExitStatus();
-			stepCtx.setExitStatus(stepCtx.getExitStatus() + data);
-			return GOOD_EXIT_STATUS;
+			return (stepCtx.getExitStatus() + data);
 		}
 
 		private String stepExitStatus() {


### PR DESCRIPTION
By refactoring the test, we avoid the discrepancy that occurs when we
set the ES via stepContext.stepExitStatus() versus setting the ES with
the batchlet return value (it is unspecified as to which method of
setting the ES takes precedence)
